### PR TITLE
[coincontrol] auto selection of inputs

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -15,6 +15,7 @@
 #include "walletmodel.h"
 #include "clientmodel.h"
 #include "platformstyle.h"
+#include <QMenu>
 
 #include "coincontrol.h"
 #include "main.h"
@@ -23,6 +24,9 @@
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
 
+#include <QComboBox>
+#include <QAbstractItemModel>
+#include <QHeaderView>
 #include <QApplication>
 #include <QCheckBox>
 #include <QCursor>
@@ -34,8 +38,10 @@
 #include <QStringList>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
-
+#include <QModelIndex>
+#include <QTableView>
 using namespace std;
+int sort;
 QList<CAmount> CoinControlDialog::payAmounts;
 int CoinControlDialog::nSplitBlockDummy;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
@@ -142,6 +148,21 @@ CoinControlDialog::CoinControlDialog(const PlatformStyle *platformStyle, QWidget
     // Toggle lock state
     connect(ui->pushButtonToggleLock, SIGNAL(clicked()), this, SLOT(buttonToggleLockClicked()));
 
+    //selection of first 50 inputs
+    connect(ui->select_50, SIGNAL(clicked()), this, SLOT(select_50()));
+
+    //selection of first 100 inputs
+    connect(ui->select_100, SIGNAL(clicked()), this, SLOT(select_100()));
+
+    //selection of first 250 inputs
+    connect(ui->select_250, SIGNAL(clicked()), this, SLOT(select_250()));
+    
+    connect(ui->GreaterThan, SIGNAL(clicked()), this, SLOT(greater()));
+
+    connect(ui->LessThan, SIGNAL(clicked()), this, SLOT(Less()));
+
+    connect(ui->EqualTo, SIGNAL(clicked()), this, SLOT(Equal()));
+
     // change coin control first column label due Qt4 bug.
     // see https://github.com/bitcoin/bitcoin/issues/5716
     ui->treeWidget->headerItem()->setText(COLUMN_CHECKBOX, QString());
@@ -159,7 +180,7 @@ CoinControlDialog::CoinControlDialog(const PlatformStyle *platformStyle, QWidget
     ui->treeWidget->setColumnHidden(COLUMN_VOUT_INDEX, true);     // store vout index in this column, but dont show it
     ui->treeWidget->setColumnHidden(COLUMN_PRIORITY_INT64, true);
     ui->treeWidget->setColumnHidden(COLUMN_DATE_INT64, true);     // store date int64 in this column, but dont show it
-
+    ui->num_box->setRange(1, 9999);
     // default view is sorted by amount desc
     sortView(COLUMN_AMOUNT, Qt::DescendingOrder);
 
@@ -241,7 +262,7 @@ void CoinControlDialog::buttonBoxClicked(QAbstractButton* button)
 // (un)select all
 void CoinControlDialog::buttonSelectAllClicked()
 {
-    Qt::CheckState state = Qt::Checked;
+ Qt::CheckState state = Qt::Checked;
     for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++) {
         if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != Qt::Unchecked) {
             state = Qt::Unchecked;
@@ -257,6 +278,179 @@ void CoinControlDialog::buttonSelectAllClicked()
         coinControl->UnSelectAll(); // just to be sure
     CoinControlDialog::updateLabels(model, this);
     CheckDialogLablesUpdated();
+}
+
+void CoinControlDialog::HideInputAutoSelection()
+{
+
+    ui->select_50->setVisible(false);
+    ui->select_100->setVisible(false);
+    ui->select_250->setVisible(false);
+    ui->GreaterThan->setVisible(false);
+    ui->LessThan->setVisible(false);
+    ui->EqualTo->setVisible(false);
+    ui->num_box->setVisible(false);
+}
+
+void CoinControlDialog::ShowInputAutoSelection()
+{
+
+    ui->select_50->setVisible(true);
+    ui->select_100->setVisible(true);
+    ui->select_250->setVisible(true);
+    ui->GreaterThan->setVisible(true);
+    ui->LessThan->setVisible(true);
+    ui->EqualTo->setVisible(true);
+    ui->num_box->setVisible(true);
+
+}
+
+void CoinControlDialog::greater()// select all inputs grater than "amount"
+{
+int val = ui->num_box->value();   
+Qt::CheckState state = Qt::Checked;  
+ui->treeWidget->setEnabled(true);
+            for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++) {
+            QTreeWidgetItem* item = ui->treeWidget->topLevelItem(i);
+            double value = item->text(COLUMN_AMOUNT).toDouble();
+    if (value > val) {
+            if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != state)
+            ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
+            ui->treeWidget->setEnabled(true);
+                if (state == Qt::Unchecked)
+                    coinControl->UnSelectAll();
+                    ui->treeWidget->setEnabled(true);
+                    CoinControlDialog::updateLabels(model, this);
+                    CheckDialogLablesUpdated();
+        }
+    } 
+} 
+
+void CoinControlDialog::Less()//select all inputs Less than "amount"
+{
+int val = ui->num_box->value();   
+Qt::CheckState state = Qt::Checked;  
+ui->treeWidget->setEnabled(true);
+            for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++) {
+            QTreeWidgetItem* item = ui->treeWidget->topLevelItem(i);
+            double value = item->text(COLUMN_AMOUNT).toDouble();
+    if (value < val) {
+            if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != state)
+            ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
+            ui->treeWidget->setEnabled(true);
+                if (state == Qt::Unchecked)
+                    coinControl->UnSelectAll();
+                    ui->treeWidget->setEnabled(true);
+                    CoinControlDialog::updateLabels(model, this);
+                    CheckDialogLablesUpdated();
+        }
+    } 
+}
+
+
+void CoinControlDialog::Equal() // select all inputs equal to "amount"
+{
+double round;
+double val = ui->num_box->value();  
+Qt::CheckState state = Qt::Checked;  
+ui->treeWidget->setEnabled(true);
+
+            for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++) {
+            QTreeWidgetItem* item = ui->treeWidget->topLevelItem(i);
+            double value = item->text(COLUMN_AMOUNT).toDouble();
+            int log = 0;
+adjusted:
+if (val > value){round = val - value; log++;}//since we can't compare "value" and "val" directly we minus the 2 and get the difference
+if (val < value){round = value - val; log++;}
+if (log == 0) { // in the event that the input and "val" are equal add a small amount and go through the sorting process again
+val = val +0.001;
+log++;
+goto adjusted;
+}
+    if (round < 0.01) { // if are input and "val" are within 0.01 of each other
+            if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != state)
+            ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
+            ui->treeWidget->setEnabled(true);
+                if (state == Qt::Unchecked)
+                    coinControl->UnSelectAll();
+                    CoinControlDialog::updateLabels(model, this);
+                    CheckDialogLablesUpdated();
+        }
+    } 
+}
+
+void CoinControlDialog::select_50() //select the first 50 inputs 
+{
+if (ui->treeWidget->topLevelItemCount() > 49){ //check we have more then 50 inputs 
+
+        Qt::CheckState state = Qt::Checked;   
+            ui->treeWidget->setEnabled(false);
+                for (int i = 0; i < 50; i++)
+                    if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != state)
+                    ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
+        ui->treeWidget->setEnabled(true);
+        if (state == Qt::Unchecked)
+            coinControl->UnSelectAll(); // just to be sure
+        CoinControlDialog::updateLabels(model, this);
+        CheckDialogLablesUpdated();
+            
+                }else { //if we have less then 50 inputs give the user dialogue to inform them of this issue  
+                QMessageBox msgBox;
+                msgBox.setObjectName("lockMessageBox");
+                msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
+                msgBox.setText(tr("Please have at least 50 inputs to use this function."));
+                msgBox.exec();
+                }
+}
+
+void CoinControlDialog::select_100()
+{
+ 
+if (ui->treeWidget->topLevelItemCount() > 99){  
+
+        Qt::CheckState state = Qt::Checked;
+            ui->treeWidget->setEnabled(false);
+                for (int i = 0; i < 100; i++)
+                    if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != state)
+                    ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
+        ui->treeWidget->setEnabled(true);
+        if (state == Qt::Unchecked)
+            coinControl->UnSelectAll(); // just to be sure
+        CoinControlDialog::updateLabels(model, this);
+        CheckDialogLablesUpdated();
+            
+                }else {  
+                QMessageBox msgBox;
+                msgBox.setObjectName("lockMessageBox");
+                msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
+                msgBox.setText(tr("Please have at least 100 inputs to use this function."));
+                msgBox.exec();
+                }
+}
+
+void CoinControlDialog::select_250()
+{
+if (ui->treeWidget->topLevelItemCount() > 249){  
+
+        Qt::CheckState state = Qt::Checked;
+            ui->treeWidget->setEnabled(false);
+                for (int i = 0; i < 250; i++)
+                    if (ui->treeWidget->topLevelItem(i)->checkState(COLUMN_CHECKBOX) != state)
+                    ui->treeWidget->topLevelItem(i)->setCheckState(COLUMN_CHECKBOX, state);
+        ui->treeWidget->setEnabled(true);
+        if (state == Qt::Unchecked)
+            coinControl->UnSelectAll(); // just to be sure
+        CoinControlDialog::updateLabels(model, this);
+        CheckDialogLablesUpdated();
+            
+            }else {  
+            QMessageBox msgBox;
+            msgBox.setObjectName("lockMessageBox");
+            msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
+                msgBox.setText(tr("Please have at least 250 inputs to use this function."));
+            msgBox.exec();
+    }
+
 }
 
 // Toggle lock state
@@ -463,6 +657,7 @@ void CoinControlDialog::headerSectionClicked(int logicalIndex)
 // toggle tree mode
 void CoinControlDialog::radioTreeMode(bool checked)
 {
+    HideInputAutoSelection(); 
     if (checked && model)
         updateView();
 }
@@ -470,6 +665,7 @@ void CoinControlDialog::radioTreeMode(bool checked)
 // toggle list mode
 void CoinControlDialog::radioListMode(bool checked)
 {
+    ShowInputAutoSelection();
     if (checked && model)
         updateView();
 }

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -16,7 +16,6 @@
 #include <QString>
 #include <QStringList>
 #include <QTreeWidgetItem>
-
 class WalletModel;
 class ClientModel;
 class PlatformStyle;
@@ -64,8 +63,10 @@ private:
     WalletModel* model;
     ClientModel* clientModel;
     int sortColumn;
+    int index;
+    int item;
     Qt::SortOrder sortOrder;
-
+    
     QMenu* contextMenu;
     QTreeWidgetItem* contextMenuItem;
     QAction* copyTransactionHashAction;
@@ -116,9 +117,16 @@ private Q_SLOTS:
     void headerSectionClicked(int);
     void buttonBoxClicked(QAbstractButton*);
     void buttonSelectAllClicked();
+    void HideInputAutoSelection();
+    void ShowInputAutoSelection();
+    void greater();
+    void Less();
+    void Equal();
+    void select_50();
+    void select_100();
+    void select_250();
     void buttonToggleLockClicked();
     void updateLabelLocked();
-
 public Q_SLOTS:
     void updateInfoInDialog();
 };

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>954</width>
+    <width>1035</width>
     <height>500</height>
    </rect>
   </property>
@@ -348,7 +348,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0">
+       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0,0,0,0">
         <property name="spacing">
          <number>14</number>
         </property>
@@ -369,18 +369,41 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButtonToggleLock">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <widget class="QPushButton" name="select_50">
+          <property name="minimumSize">
+           <size>
+            <width>115</width>
+            <height>23</height>
+           </size>
           </property>
           <property name="text">
-           <string>toggle lock state</string>
+           <string>50</string>
           </property>
-          <property name="autoDefault">
-           <bool>false</bool>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="select_100">
+          <property name="minimumSize">
+           <size>
+            <width>115</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>100</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="select_250">
+          <property name="minimumSize">
+           <size>
+            <width>114</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>250</string>
           </property>
          </widget>
         </item>
@@ -414,6 +437,22 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="pushButtonToggleLock">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>toggle lock status</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QLabel" name="labelLocked">
           <property name="text">
            <string>(1 locked)</string>
@@ -437,6 +476,60 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="GreaterThan">
+       <property name="text">
+        <string>&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="LessThan">
+       <property name="text">
+        <string>&lt;</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="EqualTo">
+       <property name="text">
+        <string>=</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="num_box">
+       <property name="minimumSize">
+        <size>
+         <width>96</width>
+         <height>20</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2"/>
    </item>
    <item>
     <widget class="CoinControlTreeWidget" name="treeWidget">


### PR DESCRIPTION
reorganised UI;
auto selection of the first 50, 100, 250 inputs; 
auto selection of an input that is greater than / less than / equal to a value the user entered 
Notes: 
(greater than / less than / equal)
-> is limited to a range of 1Lux to 9999Lux
-> buttons do NOT unselect inputs. This is to allow a user to select for example any input less than 20Lux and any input greater than 40Lux leaving all input between 20Lux and 40Lux untouched  
