### PR TITLE
[coincontrol] auto selection of inputs 

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -35,7 +35,7 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 using namespace std;
-int sort;
+
 QList<CAmount> CoinControlDialog::payAmounts;
 int CoinControlDialog::nSplitBlockDummy;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -35,7 +35,6 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 using namespace std;
-
 QList<CAmount> CoinControlDialog::payAmounts;
 int CoinControlDialog::nSplitBlockDummy;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -16,7 +16,6 @@
 #include <QString>
 #include <QStringList>
 #include <QTreeWidgetItem>
-
 class WalletModel;
 class ClientModel;
 class PlatformStyle;
@@ -64,8 +63,10 @@ private:
     WalletModel* model;
     ClientModel* clientModel;
     int sortColumn;
+    int index;
+    int item;
     Qt::SortOrder sortOrder;
-
+    
     QMenu* contextMenu;
     QTreeWidgetItem* contextMenuItem;
     QAction* copyTransactionHashAction;
@@ -112,13 +113,21 @@ private Q_SLOTS:
     void clipboardChange();
     void radioTreeMode(bool);
     void radioListMode(bool);
+    void toggled(bool);
     void viewItemChanged(QTreeWidgetItem*, int);
     void headerSectionClicked(int);
     void buttonBoxClicked(QAbstractButton*);
     void buttonSelectAllClicked();
+    void HideInputAutoSelection();
+    void ShowInputAutoSelection();
+    void greater();
+    void Less();
+    void Equal();
+    void select_50();
+    void select_100();
+    void select_250();
     void buttonToggleLockClicked();
     void updateLabelLocked();
-
 public Q_SLOTS:
     void updateInfoInDialog();
 };

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>954</width>
+    <width>1035</width>
     <height>500</height>
    </rect>
   </property>
@@ -348,42 +348,10 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0">
+       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0,0">
         <property name="spacing">
          <number>14</number>
         </property>
-        <item>
-         <widget class="QPushButton" name="pushButtonSelectAll">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>(un)select all</string>
-          </property>
-          <property name="autoDefault">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonToggleLock">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>toggle lock state</string>
-          </property>
-          <property name="autoDefault">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
         <item>
          <widget class="QRadioButton" name="radioTreeMode">
           <property name="sizePolicy">
@@ -414,6 +382,51 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="advanced">
+          <property name="minimumSize">
+           <size>
+            <width>70</width>
+            <height>17</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>advanced</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonSelectAll">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>(un)select all</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonToggleLock">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>toggle lock status</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QLabel" name="labelLocked">
           <property name="text">
            <string>(1 locked)</string>
@@ -437,6 +450,99 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QPushButton" name="select_50">
+       <property name="minimumSize">
+        <size>
+         <width>115</width>
+         <height>23</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>50</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="select_100">
+       <property name="minimumSize">
+        <size>
+         <width>115</width>
+         <height>23</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>100</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="select_250">
+       <property name="minimumSize">
+        <size>
+         <width>114</width>
+         <height>23</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>250</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="GreaterThan">
+       <property name="text">
+        <string>Greater Than</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="LessThan">
+       <property name="text">
+        <string>Less Than</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="EqualTo">
+       <property name="text">
+        <string>Equal to</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="num_box">
+       <property name="minimumSize">
+        <size>
+         <width>96</width>
+         <height>20</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2"/>
    </item>
    <item>
     <widget class="CoinControlTreeWidget" name="treeWidget">


### PR DESCRIPTION
reorganised UI;
auto selection of the first 50, 100, 250 inputs; 
auto selection of an input that is greater than / less than / equal to a value the user entered 
Notes: 
(greater than / less than / equal)
-> is limited to a range of 1Lux to 9999Lux
-> buttons do NOT unselect inputs. This is to allow a user to select for example any input less than 20Lux and any input greater than 40Lux leaving all input between 20Lux and 40Lux untouched  