### PR TITLE
hex converter and removing a not needed dialogBox for the time been.

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -102,6 +102,7 @@ QT_MOC_CPP = \
   qt/moc_contractbookpage.cpp \
   qt/moc_contractresult.cpp \
   qt/moc_contracttablemodel.cpp \
+  qt/moc_converter.cpp \
   qt/moc_createcontract.cpp \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_darksendconfig.cpp \
@@ -225,6 +226,7 @@ BITCOIN_QT_H = \
   qt/contractbookpage.h \
   qt/contractresult.h \
   qt/contracttablemodel.h \
+  qt/converter.h \
   qt/createcontract.h \
   qt/csvmodelwriter.h \
   qt/customlist.h \
@@ -491,6 +493,7 @@ BITCOIN_QT_CPP += \
   qt/contractbookpage.cpp \
   qt/contractresult.cpp \
   qt/contracttablemodel.cpp \
+  qt/converter.cpp \
   qt/createcontract.cpp \
   qt/darksendconfig.cpp \
   qt/editaddressdialog.cpp \

--- a/src/qt/addtokenpage.cpp
+++ b/src/qt/addtokenpage.cpp
@@ -12,6 +12,7 @@
 #include "addresstablemodel.h"
 #include "optionsmodel.h"
 #include "guiutil.h"
+#include "converter.h"
 
 #include <QRegularExpressionValidator>
 #include <QMessageBox>
@@ -104,10 +105,17 @@ void AddTokenPage::on_clearButton_clicked()
 
 void AddTokenPage::on_confirmButton_clicked()
 {
-    if(ui->lineEditSenderAddress->isValidAddress())
+
+    converter* addToHex = new converter();
+    bool checkedValidity = false;
+    QString convertAddrToHex = ui->lineEditContractAddress->text();
+    QString convertedAddr = "";
+    addToHex->addHexConverter(convertAddrToHex, &convertedAddr, &checkedValidity);
+
+    if(checkedValidity)
     {
         CTokenInfo tokenInfo;
-        tokenInfo.strContractAddress = ui->lineEditContractAddress->text().toStdString();
+        tokenInfo.strContractAddress = convertedAddr.toStdString();
         tokenInfo.strTokenName = ui->lineEditTokenName->text().toStdString();
         tokenInfo.strTokenSymbol = ui->lineEditTokenSymbol->text().toStdString();
         tokenInfo.nDecimals = ui->lineEditDecimals->text().toInt();
@@ -132,10 +140,12 @@ void AddTokenPage::on_confirmButton_clicked()
 
                 clearAll();
 
-                if(!fLogEvents)
-                {
-                    QMessageBox::information(this, tr("Log events"), tr("Enable log events from the option menu in order to receive token transactions."));
-                }
+/*
+            if(!fLogEvents)
+            {
+                QMessageBox::information(this, tr("Log events"), tr("Enable log events from the option menu in order to receive token transactions."));
+            }
+*/
             }
         }
     }
@@ -143,10 +153,22 @@ void AddTokenPage::on_confirmButton_clicked()
 
 void AddTokenPage::on_addressChanged()
 {
+
+    converter* addToHex = new converter();
+    bool checkedValidity = false;
     QString tokenAddress = ui->lineEditContractAddress->text();
+    QString convertedAddr = "";
+    addToHex->addHexConverter(tokenAddress, &convertedAddr, &checkedValidity);
+
+    if(tokenAddress.isEmpty()) {
+        ui->lineEditContractAddress->setValid(true);
+    } else {
+        ui->lineEditContractAddress->setValid(checkedValidity);
+    }
+
     if(m_tokenABI)
     {
-        m_tokenABI->setAddress(tokenAddress.toStdString());
+        m_tokenABI->setAddress(convertedAddr.toStdString());
         std::string name, symbol, decimals;
         bool ret = m_tokenABI->name(name);
         ret &= m_tokenABI->symbol(symbol);

--- a/src/qt/converter.cpp
+++ b/src/qt/converter.cpp
@@ -1,0 +1,95 @@
+#include "converter.h"
+#include "base58.h"
+#include "uint256.h"
+#include "utilstrencodings.h"
+
+#include <iostream>
+#include <QClipboard>
+#include <QRegularExpressionValidator>
+
+#define paternAddress "^[a-fA-F0-9]{40,40}$"
+
+void converter::addHexConverter(const QString address, QString* convertedAddr, bool* checkedValidity) {
+
+    if(!address.isEmpty()) {
+
+        bool hasHexAddress = false;
+        QRegularExpression regEx(paternAddress);
+        hasHexAddress = regEx.match(address).hasMatch();
+        if (hasHexAddress) {
+            *convertedAddr = address;
+            *checkedValidity = hasHexAddress;
+        }
+
+        bool hasLuxAddress = false;
+        CTxDestination addr = DecodeDestination(address.toStdString());
+        hasLuxAddress = IsValidDestination(addr);
+        if (hasLuxAddress) {
+            CKeyID *keyid = boost::get<CKeyID>(&addr);
+            if (keyid) {
+                *convertedAddr = QString::fromStdString(HexStr(valtype(keyid->begin(),keyid->end())));
+                *checkedValidity = hasLuxAddress;
+            }
+        }
+    }
+}
+
+void converter::addAddrConverter(const QString address, QString* convertedAddr, bool* checkedValidity) {
+
+    if(!address.isEmpty()) {
+
+        bool hasHexAddress = false;
+        QRegularExpression regEx(paternAddress);
+        hasHexAddress = regEx.match(address).hasMatch();
+        if (hasHexAddress) {
+            uint160 key(ParseHex(address.toStdString()));
+            CKeyID keyid(key);
+            if(IsValidDestination(CTxDestination(keyid))) {
+                *convertedAddr = QString::fromStdString(EncodeDestination(CTxDestination(keyid)));
+            }
+            *checkedValidity = hasHexAddress;
+        }
+
+        bool hasLuxAddress = false;
+        CTxDestination addr = DecodeDestination(address.toStdString());
+        hasLuxAddress = IsValidDestination(addr);
+        if (hasLuxAddress) {
+            CKeyID *keyid = boost::get<CKeyID>(&addr);
+            if (keyid) {
+                *convertedAddr = address;
+                *checkedValidity = hasLuxAddress;
+            }
+        }
+    }
+}
+
+void converter::twoWayConverter(const QString address, QString *convertedAddr, bool *checkedValidityHex, bool *checkedValidityAddr) {
+
+    if(!address.isEmpty()) {
+
+        bool hasHexAddress = false;
+        QRegularExpression regEx(paternAddress);
+        hasHexAddress = regEx.match(address).hasMatch();
+        if (hasHexAddress) {
+            uint160 key(ParseHex(address.toStdString()));
+            CKeyID keyid(key);
+            if(IsValidDestination(CTxDestination(keyid))) {
+                *convertedAddr = QString::fromStdString(EncodeDestination(CTxDestination(keyid)));
+            }
+            *checkedValidityHex = hasHexAddress;
+            *checkedValidityAddr = false;
+        }
+
+        bool hasLuxAddress = false;
+        CTxDestination addr = DecodeDestination(address.toStdString());
+        hasLuxAddress = IsValidDestination(addr);
+        if (hasLuxAddress) {
+            CKeyID *keyid = boost::get<CKeyID>(&addr);
+            if (keyid) {
+                *convertedAddr = QString::fromStdString(HexStr(valtype(keyid->begin(),keyid->end())));
+                *checkedValidityAddr = hasLuxAddress;
+                *checkedValidityHex = false;
+            }
+        }
+    }
+}

--- a/src/qt/converter.h
+++ b/src/qt/converter.h
@@ -1,0 +1,16 @@
+#ifndef CONVERTER_H
+#define CONVERTER_H
+
+#include <QObject>
+#include <QString>
+
+class converter
+{
+
+public:
+    void addHexConverter(const QString address, QString *convertedAddr, bool *checkedValidity);
+    void addAddrConverter(const QString address, QString *convertedAddr, bool *checkedValidity);
+    void twoWayConverter(const QString address, QString *convertedAddr, bool *checkedValidityHex, bool *checkedValidityAddr);
+};
+
+#endif

--- a/src/qt/forms/addtokenpage.ui
+++ b/src/qt/forms/addtokenpage.ui
@@ -92,7 +92,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLineEdit" name="lineEditContractAddress">
+      <widget class="QValidatedLineEdit" name="lineEditContractAddress">
        <property name="alignment">
         <set>Qt::AlignCenter</set>
        </property>

--- a/src/qt/sendtokenpage.cpp
+++ b/src/qt/sendtokenpage.cpp
@@ -41,9 +41,9 @@ SendTokenPage::SendTokenPage(QWidget *parent) :
     m_selectedToken(0)
 {
     ui->setupUi(this);
-    ui->labelPayTo->setToolTip(tr("The address that will receive the tokens."));
-    ui->labelAmount->setToolTip(tr("The amount in LSR Token to send."));
-    ui->labelDescription->setToolTip(tr("Optional description for transaction."));
+    ui->lineEditPayTo->setToolTip(tr("The address that will receive the tokens."));
+    ui->lineEditAmount->setToolTip(tr("The amount in LSR Token to send."));
+    ui->lineEditDescription->setToolTip(tr("Optional description for transaction."));
     m_tokenABI = new Token();
     m_selectedToken = new SelectedToken();
 
@@ -151,9 +151,9 @@ void SendTokenPage::on_numBlocksChanged(int newHeight)
             uint64_t nGasPrice = 0;
             m_clientModel->getGasInfo(blockGasLimit, minGasPrice, nGasPrice);
 
-            ui->labelGasLimit->setToolTip(
+            ui->lineEditGasLimit->setToolTip(
                     tr("Gas limit: Default = %1, Max = %2.").arg(DEFAULT_GAS_LIMIT_OP_SEND).arg(blockGasLimit));
-            ui->labelGasPrice->setToolTip(tr("Gas price: LUX/gas unit. Default = %1, Min = %2.").arg(
+            ui->lineEditGasPrice->setToolTip(tr("Gas price: LUX/gas unit. Default = %1, Min = %2.").arg(
                     QString::fromStdString(FormatMoney(DEFAULT_GAS_PRICE))).arg(
                     QString::fromStdString(FormatMoney(minGasPrice))));
             ui->lineEditGasPrice->setMinimum(minGasPrice);
@@ -176,10 +176,9 @@ void SendTokenPage::on_updateConfirmButton()
 
 void SendTokenPage::on_confirmClicked()
 {
-    if(!isDataValid())
-        return;
+    if(!isDataValid()) return;
 
-WalletModel::UnlockContext ctx(m_model->requestUnlock());
+    WalletModel::UnlockContext ctx(m_model->requestUnlock());
     if(!ctx.isValid()) {
         return;
     }


### PR DESCRIPTION
Converter.cpp & Converter.h added to have 3 functions (hex->hex, addr->hex), (hex->addr, addr->hex),(addr->addr, hex->addr)
moved function from hexaddressconverter to converter.cpp and applied code appropriately so it continues to work
addtokenpage.cpp - now allows to enter Addr and Hex when adding new coins, removed dialogBox when new coin is added
sendtokenpage.cpp - moved some tooltip from labels to input boxes.
addtokenpage.ui changed input box to one that validates addess field


Signed-off-by: TopoX